### PR TITLE
Add PatternDisable event call to example LED program

### DIFF
--- a/docs/tildagon-apps/widgets-and-hardware/badge-hardware.md
+++ b/docs/tildagon-apps/widgets-and-hardware/badge-hardware.md
@@ -24,7 +24,6 @@ class LEDExampleApp(app.App):
         # This disables the patterndisplay system module, which does the default colour spinny thing
         eventbus.emit(PatternDisable())
 
-
     def update(self, delta):
         if self.button_states.get(BUTTON_TYPES["RIGHT"]):
             tildagonos.leds[2] = (255, 0, 0)

--- a/docs/using-the-badge/end-user-manual.md
+++ b/docs/using-the-badge/end-user-manual.md
@@ -3,6 +3,8 @@ title: Tildagon End User Manual
 weight: 1
 ---
 
+!!! warning "Apps can be published on the [app store](https://apps.badge.emfcamp.org/) but currently do not run on the badge yet. The badge team are currently working on this as fast as they can, please be patient!"
+
 ![A hexagonal camp badge, with three smaller hexagonal PCBs containing breakout
 pins peaking out from the edges, and a screen showing
 @emfcamp](../images/badge-photos/badge-with-screen.jpg "Tildagon with attached


### PR DESCRIPTION
Add call to the PatternDisable event, otherwise the pattern display module tries to control the LEDs at the same time.