### PR TITLE
fix instructions for connecting to non-wpa2enterprise networks

### DIFF
--- a/docs/using-the-badge/connect-to-wifi.md
+++ b/docs/using-the-badge/connect-to-wifi.md
@@ -33,6 +33,7 @@ Probably the simplest option is to open [Tildagon Flasher](https://emfcamp.githu
 import settings
 settings.set("wifi_ssid", "changeme")
 settings.set("wifi_password", "changeme")
+settings.set("wifi_wpa2ent_username", None)
 settings.save()
 ```
 

--- a/docs/using-the-badge/connect-to-wifi.md
+++ b/docs/using-the-badge/connect-to-wifi.md
@@ -15,7 +15,7 @@ This is the easiest option, but a real pain to do because you have to type out e
 1. On the home screen scroll down to settings using the D key, and enter using C key.
 2. Scroll through the key to "WIFI SSID" and press enter.
 3. Use the up and down keys to select each letter, pressing B to select.
-4. Press B to save.
+4. Press C to save.
 5. Repeat for the "WIFI password" option.
 6. Push the Reboop button and try connecting.
 

--- a/docs/using-the-badge/connect-to-wifi.md
+++ b/docs/using-the-badge/connect-to-wifi.md
@@ -33,6 +33,7 @@ Probably the simplest option is to open [Tildagon Flasher](https://emfcamp.githu
 import settings
 settings.set("wifi_ssid", "changeme")
 settings.set("wifi_password", "changeme")
+# If connecting to non-wpa2enterprise networks
 settings.set("wifi_wpa2ent_username", None)
 settings.save()
 ```


### PR DESCRIPTION
was attempting to connect my tildagon to my wpa2 home network - looking at the firmware, the `wifi_wpa2ent_username` setting needs to be `None` to use wpa2 auth.