### PR TITLE
Correct checksum calculation in eeprom example

### DIFF
--- a/docs/hexpansions/eeprom.md
+++ b/docs/hexpansions/eeprom.md
@@ -135,9 +135,9 @@ The filesystem should contain a file named `app.py` which contains MicroPython c
 
 - Magic "THEX"
 - Version "2024"
-- Filesystem offset 64 bytes (0x4000)
-- Filesystem page size 64 bytes (0x4000)
-- Filesystem total size 64k (0x00000100)
+- Filesystem offset 64 bytes (0x0040)
+- Filesystem page size 64 bytes (0x0040)
+- Filesystem total size 64k (0x00010000)
 - VID 0xf055
 - PID 0x0001
 - Unique ID in use, value 0x0002

--- a/docs/hexpansions/eeprom.md
+++ b/docs/hexpansions/eeprom.md
@@ -131,7 +131,7 @@ The filesystem should contain a file named `app.py` which contains MicroPython c
 
 ### Example
 
-`b'THEX2024\x40\x00\\x40\x00\x00\x00\x01\x00\x55\xf0\x01\x00\x02\x00EXAMPLE\x00\x00\x8b'`
+`b'THEX2024\x40\x00\x40\x00\x00\x00\x01\x00\x55\xf0\x01\x00\x02\x00EXAMPLE\x00\x00\xeb'`
 
 - Magic "THEX"
 - Version "2024"
@@ -142,7 +142,7 @@ The filesystem should contain a file named `app.py` which contains MicroPython c
 - PID 0x0001
 - Unique ID in use, value 0x0002
 - Friendly name is "EXAMPLE" (padded with zeroes)
-- Checksum is 0x8b
+- Checksum is 0xeb
 
 (header length: 32 bytes)
 


### PR DESCRIPTION
# Description

The serialised eeprom header in the example includes an erroneous backslash that resulted in the example checksum being incorrect. Removing the extra backslash gives a checksum value of 0xeb rather than 0x8b.

I've also swapped the endianness of the FS parameters in the explanation to be consistent with standard big-endian `0x` representation and the explanations for the other fields - it wasn't obvious why my code was calculating a different checksum value and this inconsistency was a contributing factor.
