### PR TITLE
Minor fixes

### DIFF
--- a/docs/tildagon-apps/run-on-badge.md
+++ b/docs/tildagon-apps/run-on-badge.md
@@ -10,11 +10,11 @@ You can test your app on-device, without publishing it, using [`mpremote`](https
    ```json
    {
      "name": "<app-name>",
-     "path": "apps.<folder-name>.app"
+     "path": "apps.<folder-name>.<source-name>"
    }
    ```
 
-   The folder name is the name of the folder you will copy the app to. For example:
+   The folder name is the name of the folder you will copy the app to. The source name is the name of the Python source file containing your app, without the `.py` extension. For example, if your app is in a file called `app.py`:
 
    ```json
    {


### PR DESCRIPTION
Fixed the pins example app, and clarified the `name` property in `metadata.json`.

The pins example app had three issues:

- The app raised an exception when you selected a hexpansion port
- The graphical indication of the active hexpansion port was off by one
- There was no way to go back to the hexpansion port selection menu

Tested on badge with the latest firmware.