### PR TITLE
Update ESPNOW badge comms docs

### DIFF
--- a/docs/tildagon-apps/examples/inter-badge-communications.md
+++ b/docs/tildagon-apps/examples/inter-badge-communications.md
@@ -5,8 +5,10 @@ weight: 3
 
 [Here is a demo of using ESPNOW to achieve badge-to-badge communication](https://github.com/ntflix/TildaDrop).
 
-As noted in the repo, currently this only works when the sender knows the receiver's MAC address.
-Broadcast functionality, which does not require the MAC address of a recipient, does not seem to work as it shows in the [espnow docs](https://docs.micropython.org/en/latest/library/espnow.html#broadcast-and-multicast).
+~~As noted in the repo, currently this only works when the sender knows the receiver's MAC address.
+Broadcast functionality, which does not require the MAC address of a recipient, does not seem to work as it shows in the [espnow docs](https://docs.micropython.org/en/latest/library/espnow.html#broadcast-and-multicast).~~
+
+> As of Tildagon OS 1.9.0, broadcast functionality works, so you can send messages to all badges in 'receiving' mode without needing to know their MAC addresses. Use the broadcast MAC address `b'\xff\xff\xff\xff\xff\xff'` to send messages to all badges.
 
 MAC address can be found through like so:
 
@@ -23,4 +25,3 @@ print(f"MAC address: {mac_str}")
 ```
 
 [See the ESPNOW MicroPython docs for more information and inspiration](https://docs.micropython.org/en/latest/library/espnow.html).
-If you get broadcast working, please submit a PR on these docs with your solution.


### PR DESCRIPTION
It is stated in [Inter-Badge Communication](https://tildagon.badge.emfcamp.org/tildagon-apps/examples/inter-badge-communications/) that broadcast functionality using [ESP-NOW](https://docs.micropython.org/en/latest/library/espnow.html) does not work. This is now out-of-date and incorrect.

Broadcast functionality now works in Tildagon OS 1.9.0, so the docs are updated to reflect this. This was verified using the [TildaDrop](https://github.com/ntflix/TildaDrop/) app using two Tildagons.