### PR TITLE
Fix reading hexpansion headers

### DIFF
--- a/docs/hexpansions/writing-hexpansion-apps.md
+++ b/docs/hexpansions/writing-hexpansion-apps.md
@@ -126,14 +126,14 @@ Below is an example of how you find which port your hexpansion is plugged in to 
             for port in range(1, 7):
                 print(f"Searching for hexpansion on port: {port}")
                 i2c = I2C(port)
-                addr,addr_len = detect_eeprom_addr(i2c) # Firmware version 1.8 and upwards only!
+                addr, addr_len = detect_eeprom_addr(i2c) # Firmware version 1.8 and upwards only!
 
                 if addr is None:
                     continue
                 else:
                     print("Found EEPROM at addr " + hex(addr))
 
-                header = read_hexpansion_header(i2c, addr)
+                header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
                 if header is None:
                     continue
                 else:

--- a/docs/tildagon-apps/backgrounds.md
+++ b/docs/tildagon-apps/backgrounds.md
@@ -50,6 +50,7 @@ def draw(self, ctx):
     bg.draw(ctx)
     # add you code
 
+
 def update(self, delta):
     bg.update(delta)
     # add you code

--- a/docs/tildagon-apps/backgrounds.md
+++ b/docs/tildagon-apps/backgrounds.md
@@ -46,11 +46,11 @@ from app_components.background import Background as bg
 then call the update and draw functions from the same functions in your app:
 
 ```python
-    def draw(self, ctx):
-        bg.draw(ctx)
-        # add you code
+def draw(self, ctx):
+    bg.draw(ctx)
+    # add you code
 
-    def update(self, delta):
-        bg.update(delta)
-        # add you code
+def update(self, delta):
+    bg.update(delta)
+    # add you code
 ```

--- a/docs/tildagon-apps/examples/detect-hexpansion.md
+++ b/docs/tildagon-apps/examples/detect-hexpansion.md
@@ -56,14 +56,14 @@ class ExampleApp(app.App):
         for port in range(1, 7):
             print(f"Searching for hexpansion on port: {port}")
             i2c = I2C(port)
-            addr = detect_eeprom_addr(i2c)
+            addr, addr_len = detect_eeprom_addr(i2c)
 
             if addr is None:
                 continue
             else:
                 print("Found EEPROM at addr " + hex(addr))
 
-            header = read_hexpansion_header(i2c, addr)
+            header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
             if header is None:
                 continue
             else:

--- a/docs/tildagon-apps/reference/badge-hardware.md
+++ b/docs/tildagon-apps/reference/badge-hardware.md
@@ -698,14 +698,14 @@ bus = I2C(1)
             for port in range(1, 7):
                 print(f"Searching for hexpansion on port: {port}")
                 i2c = I2C(port)
-                addr = detect_eeprom_addr(i2c)
+                addr, addr_len = detect_eeprom_addr(i2c)
 
                 if addr is None:
                     continue
                 else:
                     print("Found EEPROM at addr " + hex(addr))
 
-                header = read_hexpansion_header(i2c, addr)
+                header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
                 if header is None:
                     continue
                 else:


### PR DESCRIPTION
# Description

The documentation for reading a hexpansion header had sample code that has been broken since v1.8.0, due to a backwards-incompatible. Fix these, by adding the addr length.
