### PR TITLE
Add note about app repo contents

### DIFF
--- a/docs/tildagon-apps/publish.md
+++ b/docs/tildagon-apps/publish.md
@@ -10,6 +10,10 @@ To publish your Tildagon App, you need to create a GitHub repository with:
 - a [release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)
 - the `tildagon-app` [topic applied to the repo](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository)
 
+!!! note "Release contents"
+
+      The repo should only contain the files required for the app itself as the entire repo is downloaded as a tar.gz and extracted on the badge and there is limited space. For example, images for the readme are also downloaded.
+
 ## Instructions
 
 1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this [GitHub repository](https://github.com/hughrawlinson/tildagon-demo/).


### PR DESCRIPTION
# Description

add a note to say only include what's needed due to the app repo being downloaded in full onto the badge.
