### PR TITLE
use event instead of emit

### DIFF
--- a/docs/tildagon-apps/reference/badge-hardware.md
+++ b/docs/tildagon-apps/reference/badge-hardware.md
@@ -590,12 +590,16 @@ from system.hexpansion.events import \
     HexpansionRemovalEvent, HexpansionInsertionEvent
 ```
 
-Then `emit()` the event as following:
+Then attach a function to the event as following:
 
 ```python
-eventbus.emit(
-    events.RequestChargeEvent(events.PowerEvent("Charge Cycle change"))
-)
+class ChargeApp(app.App):
+    def __init__(self):
+        eventbus.on(events.RequestChargeEvent, self._handle_charge_event, self)
+
+    def _handle_charge_event(self, event: RequestChargeEvent):
+        # do something
+        return None
 ```
 
 ## I2C


### PR DESCRIPTION
# Description

Please include a summary of the change and what is does. Please also include relevant motivation and context.
The power and hexpansion events docs had an emit() to create the event. changed it to show how to use the events to trigger something as these are emitted by the badge
