### PR TITLE
Update site description to include 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Tildagon Badge Documentation
-site_description: "Documentation for the Tildagon Badge used at Electromagnetic Field 2024."
+site_description: "Documentation for the Tildagon Badge used at Electromagnetic Field 2024 and 2026."
 site_url: https://tildagon.badge.emfcamp.org
 repo_url: https://github.com/emfcamp/badge-2024-documentation
 theme:


### PR DESCRIPTION
# Description

Shared the badge docs with someone unfamiliar with EMF and realised that the URL preview implied the badge was old news. Now we know it's definitely being used in 2026, we should add it to the description! 