### PR TITLE
Add a link to EMF /about/badge page to get a badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Unlike in previous years, [Electromagnetic Field](https://www.emfcamp.org/) is t
 
 <div class="grid cards" markdown>
 
+- [I want to get my own badge](https://www.emfcamp.org/about/badge)
 - [I want to know how to assemble and use the badge](using-the-badge/end-user-manual.md)
 - [I want to connect to another Wi-Fi network](using-the-badge/connect-to-wifi.md)
 - [I want to make a badge app](tildagon-apps/development.md)


### PR DESCRIPTION
Add a link to the EMF /about/badge page to get your own badge.

Pending https://github.com/emfcamp/Website/pull/2110