### PR TITLE
fix: Correct wifi-switcher address

### DIFF
--- a/docs/using-the-badge/connect-to-wifi.md
+++ b/docs/using-the-badge/connect-to-wifi.md
@@ -7,7 +7,7 @@ There are several ways to connect your Tildagon to Wi-Fi depending on what appro
 
 !!! tip "Switch between multiple Wi-Fi networks"
 
-    If you regularly move between several networks (for example home, work, and a makerspace), install [Wifi Switcher](https://apps.badge.emfcamp.org/apps/40433243/) from the app store. Use **CodeInstall** and enter **40433243** to install it. The app saves multiple network profiles so you can switch between them on the badge without retyping your SSID and password each time.
+    If you regularly move between several networks (for example home, work, and a makerspace), install [Wifi Switcher](https://apps.badge.emfcamp.org/apps/40333313/) from the app store. Use **CodeInstall** and enter **40333313* to install it. The app saves multiple network profiles so you can switch between them on the badge without retyping your SSID and password each time.
 
 ## Option 1 - Through the GUI
 


### PR DESCRIPTION
# Description
As detailed in <https://github.com/RichardoC/wifi-switcher/issues/3> I need to link to a more modern version of wifi-switcher, that works on the more modern tildagon version
