### PR TITLE
Remove app and rgb from ButtonDisplay

### DIFF
--- a/docs/tildagon-apps/reference/ui-elements.md
+++ b/docs/tildagon-apps/reference/ui-elements.md
@@ -860,9 +860,7 @@ To use layouts:
         ```python
         button_display = ButtonDisplay(
             text="Select me",
-            app=self,
             font_size=8,
-            rgb=(50, 0, 0),
             button_handler=self.select_handler)
         self.layout.items.append(button_display)
         ```
@@ -872,9 +870,7 @@ To use layouts:
         | Parameter | Type | Description |
         | --------- | ---- | ----------- |
         | `text` | `str` | The long text to display. |
-        | `app` | `App` | The app to add the button display to. |
         | `font_size` | `int` | The font size to display the text in. |
-        | `rgb` | `tuple` | The color to display the text in. |
         | `button_handler` | `method` | The handler for button events. |
 
         Create an asynchronous `select_handler` that does something when a button is pressed:


### PR DESCRIPTION
There is no app parameter so there is a syntax error if you try to use it.

The rgb parameter exists but is un-used: the button gets its colours from tokens.ui_colours