### PR TITLE
Correct scale of TextDisplay RGB example

### DIFF
--- a/docs/tildagon-apps/reference/ui-elements.md
+++ b/docs/tildagon-apps/reference/ui-elements.md
@@ -839,7 +839,7 @@ To use layouts:
         Initialize the text_display in your `__init__` or in your `update` method and add it to the `self.layout.items` variable:
 
         ```python
-        text_display = TextDisplay("My long text", font_size=8, rgb=(0, 0, 50))
+        text_display = TextDisplay("My long text", font_size=8, rgb=(0, 0, 1))
         self.layout.items.append(text_display)
         ```
 


### PR DESCRIPTION
This parameter is passed through to ctx.rgb and so should use 0 .. 1 as the scale.

The previous example of 50 seems like it was meant to be very-dark-blue on a scale of 0 .. 255, but was actually saturating at 1 to mean "full brightness", the same as 1.
