### PR TITLE
Fix radial gradient to look more like screenshot

### DIFF
--- a/docs/tildagon-apps/reference/ctx.md
+++ b/docs/tildagon-apps/reference/ctx.md
@@ -284,9 +284,9 @@ class ExampleApp(app.App):
         clear_background(ctx)
         ctx.save()
 
-        ctx.radial_gradient(30, 30, 80, -30, -50, 70)
-        ctx.add_stop(0, (100, 0, 100), 0.5)
-        ctx.add_stop(1, (100, 0, 0), 0.8)
+        ctx.radial_gradient(0, 0, 80, 0, 0, 20)
+        ctx.add_stop(0, (0.5, 0, 0), 0.9)
+        ctx.add_stop(1, (0.5, 0, 0.5), 0.5)
         ctx.rectangle(-100, -100, 200, 200).fill()
 
         ctx.restore()


### PR DESCRIPTION
In the existing screenshot the centre of the gradient is the centre of the display. This PR changes the code to make that so - using coordinates 0,0 for both.

The ctx source code also contains a note that only the 2nd central point is used and that the first one is ignored.

The colour order is flipped so that red is on the outside and purple of the inside, like in the screenshot.

The radius of the gradient band is changed: before this PR, it was 70 - 80 pixels out, which is only a 10 pixel band for the gradient. This PR changes it to a wider 60 pixel band (20 to 80 pixels out)

The colours look like they should be specified as floats between 0-1 although the larger values don't cause an error message. (but I think they're clipped at 1.0?)

before this PR:

<img width="577" height="1280" alt="image" src="https://github.com/user-attachments/assets/aca9b42c-beb1-4f91-aaf1-1066dabc6df9" />

after this PR:

<img width="577" height="1280" alt="image" src="https://github.com/user-attachments/assets/5c075381-d2ab-4b22-8956-6f1c5a20c49a" />

