### PR TITLE
fix callouts

### DIFF
--- a/docs/tildagon-apps/patterns.md
+++ b/docs/tildagon-apps/patterns.md
@@ -89,9 +89,9 @@ __pattern_export__ = CyclePattern
 __Pattern_Export__ = CyclePattern
 ```
 
-> [!WARNING]
-> **Important Casing Discrepancy:**
-> Currently, Tildagon OS has a casing mismatch in how patterns are handled. The **App Store** (UI catalog) looks for `__Pattern_Export__` (capital `P` and capital `E`) to discover the app, while the **PatternDisplay** engine looks for `__pattern_export__` (all lowercase) to run it. You **must** export your pattern class under both names (as shown above) to ensure the pattern is both visible and executable.
+!!! warning "Important Casing Discrepancy"
+
+    Currently, Tildagon OS has a casing mismatch in how patterns are handled. The **App Store** (UI catalog) looks for `__Pattern_Export__` (capital `P` and capital `E`) to discover the app, while the **PatternDisplay** engine looks for `__pattern_export__` (all lowercase) to run it. You **must** export your pattern class under both names (as shown above) to ensure the pattern is both visible and executable.
 
 ---
 
@@ -187,6 +187,6 @@ class DirectControlApp(app.App):
             self.minimise()
 ```
 
-> [!TIP]
-> **Brightness is handled automatically:**
-> You do not need to read the user's pattern brightness setting or scale your RGB values. The `PatternDisplay` engine automatically scales all colours returned by `next()` using the global brightness configuration. Always return your colours at their full intended brightness (0-255).
+!!! info "Brightness is handled automatically"
+
+    You do not need to read the user's pattern brightness setting or scale your RGB values. The `PatternDisplay` engine automatically scales all colours returned by `next()` using the global brightness configuration. Always return your colours at their full intended brightness (0-255).


### PR DESCRIPTION
- **fix: Correct wifi-switcher address (#326)**
- **Fix radial gradient to look more like screenshot (#329)**
- **Correct scale of TextDisplay RGB example (#328)**
- **Remove app and rgb from ButtonDisplay (#327)**
- **Add more hexpansions (#330)**
- **Add a link to EMF /about/badge page to get a badge (#321)**
- **Added details about how hexpansion app deinit (#325)**
- **Update per element chat (#331)**
- **Add more info for eeprom (#310)**
- **Update branding to 2026 colours (#314)**
- **Add documentation for new hexpansion utility methods (#292)**
- **document Pattern type apps (#306)**
- **Redo "badge app 101" instructions (#324)**
- **fix: callout markup in pattern apps docs**

# Description

Please include a summary of the change and what is does. Please also include relevant motivation and context.
