### PR TITLE
Update ui-elements.md

### DIFF
--- a/docs/tildagon-apps/reference/ui-elements.md
+++ b/docs/tildagon-apps/reference/ui-elements.md
@@ -891,7 +891,10 @@ To use layouts:
 
 ## Tokens
 
-The [`Tokens`](https://github.com/emfcamp/badge-2024-software/blob/main/modules/app_components/tokens.py) component allows you to use: - functions for clearing the background and setting a color - constants for the display properties and colors
+The [`Tokens`](https://github.com/emfcamp/badge-2024-software/blob/main/modules/app_components/tokens.py) component allows you to use:
+
+- functions for clearing the background and setting a color
+- constants for the display properties and colors
 
 ### Functions
 


### PR DESCRIPTION
Minor fix to markdown list of the "Token" description

# Description

The description of the "Tokens" doc under UI widget overview appeared to have a two item bullet point list that was in-lined in the markdown. This change just converts the in-line text to a proper markdown list.

It might be that it's intended to be formatted like it is, in which case this should be closed without further action :)
