### PR TITLE
callout fix and casing

### DIFF
--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -119,12 +119,12 @@ Tildagon Event Bus, check out our [reference documentation][Tildagon Event Bus].
 Capabilities are not restricted to using the event bus - they can specify that
 devices are available on a given [I2C
 Bus](https://tildagon.badge.emfcamp.org/tildagon-apps/reference/badge-hardware/#i2c),
-and even that specific micropython code can be imported from a given path.
+and even that specific MicroPython code can be imported from a given path.
 
-!!! note Work in Progress
+!!! note "Work in Progress"
 
     Badge Team is working hard to get hardware and software ready for EMF 2026.
-    We will document cross-app micropython imports as soon as possible.
+    We will document cross-app MicroPython imports as soon as possible.
 
 ## Can apps declare a requirement for a specific hexpansion by it's VID/PID pair?
 
@@ -145,7 +145,7 @@ feature = {
 
 The `required` value specifies whether the feature is required or supported
 
-!!! note What is a feature in contrast to a Capability?
+!!! note "What is a feature in contrast to a Capability?"
 
     Apps can require, support or provide Capabilities, but they can also
     require or support a specific hexpansion by its VID and PID, a Frontboard, or a


### PR DESCRIPTION
Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>

# Description

Simple cleanup - two broken note callouts, and two corrections for micropython -> MicroPython.
