### PR TITLE
Add index to select_handler() in examples

### DIFF
--- a/docs/tildagon-apps/reference/ui-elements.md
+++ b/docs/tildagon-apps/reference/ui-elements.md
@@ -25,7 +25,7 @@ class MenuDemo(App):
         )
         self.notification = None
 
-    def select_handler(self, item):
+    def select_handler(self, item, idx):
         self.notification = Notification('You selected "' + item + '"!')
 
     def back_handler(self):
@@ -105,7 +105,7 @@ To use a menu:
            self.minimise()
        self.set_menu("main")
 
-   def select_handler(self, item):
+   def select_handler(self, item, idx):
        # Do something based on the selection, like moving to a new menu or performing an action.
 
    ```


### PR DESCRIPTION
# Description

Add the `idx` (index) argument to the examples on https://tildagon.badge.emfcamp.org/tildagon-apps/reference/ui-elements/

Otherwise, if you uses the example code as is you get:
`TypeError: function takes 2 positional arguments but 3 were given`

e.g. see https://github.com/emfcamp/badge-2024-software/issues/91

Steps to reproduce:
Run the first example code from https://tildagon.badge.emfcamp.org/tildagon-apps/reference/ui-elements/