### PR TITLE
add a brief autoexec.bat note

### DIFF
--- a/docs/tildagon-apps/autoexec.md
+++ b/docs/tildagon-apps/autoexec.md
@@ -1,0 +1,20 @@
+---
+title: Run an app automatically at startup
+---
+
+You can make your badge run an app automatically at startup, for example if you would like a namebadge app to start rather than the default launcher.
+
+Create a file called `autoexec.bat` on your Tildagon, containing the name of the app you would like to start, as named in the launcher menu.
+
+For example, you can use `mpremote`:
+
+   ```sh
+   mpremote edit :/autoexec.bat
+   ```
+
+If you'd chosen to launch the built-in settings app, you would then see this:
+
+   ```sh
+   $ mpremote cat :/autoexec.bat
+   Settings
+   ```


### PR DESCRIPTION
This functionality was added in badge firmware 2.0.0-alpha7, https://github.com/emfcamp/badge-2024-software/pull/367

I'm unsure where this text actually belongs. It was a bit of an arbitrary decision to put it in the section that feels more about developing apps, because its more a "want to do weird stuff as a user" functionality. So if anyone has a better location...