### PR TITLE
Fix example tildagon.json to match parser

### DIFF
--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -50,8 +50,10 @@ capability = { type = "Capability", identifier = "https://tildagon.badge.emfcamp
   "metadata": {
     "providedCapabilities": [
       {
-        "type": "ProvidedCapability",
-        "identifier": "https://tildagon.badge.emfcamp.org/capabilities/registry/mysterious-pings"
+        "capability": {
+          "type": "ProvidedCapability",
+          "identifier": "https://tildagon.badge.emfcamp.org/capabilities/registry/mysterious-pings"
+        }
       }
     ]
   }


### PR DESCRIPTION
# Description
`get_app_capabilities()` expects a capability entry.

Otherwise I get `KeyError: capability` in `get_app_capabilities()`.

