### PR TITLE
Fix: step-13-display-cable-2.jpg

### DIFF
--- a/docs/using-the-badge/spaceagon-assembly.md
+++ b/docs/using-the-badge/spaceagon-assembly.md
@@ -126,7 +126,7 @@ Lift the black flap of the display connector and slide in the display cable.
 
 ![Lift the flap of the display connector](../images/spaceagon-assembly/step-13-display-cable-1.jpg){: style="width:550px;height: auto;" }
 
-![Attach the ribbon cable](../images/spaceagon-assembly/step-13-display-cable-1.jpg){: style="width:550px;height: auto;" }
+![Attach the ribbon cable](../images/spaceagon-assembly/step-13-display-cable-2.jpg){: style="width:550px;height: auto;" }
 
 ### Step 14: Attach the battery
 


### PR DESCRIPTION
# Description

The image step-13-display-cable-1.jpg is incorrectly included twice in the instructions, the second instance should be step-13-display-cable-2.jpg